### PR TITLE
Deserialize order creation response as Order model

### DIFF
--- a/src/Linker/Api/Client/HttpApiClient.php
+++ b/src/Linker/Api/Client/HttpApiClient.php
@@ -115,7 +115,8 @@ class HttpApiClient implements LinkerClientInterface
             'body'    => $content
         ];
         try {
-            return $this->client->request('POST', $endpoint, $options);
+            $response = $this->client->request('POST', $endpoint, $options);
+            return $this->serializer->deserialize((string)$response->getBody(), Order::class, 'json');
         } catch (ServerException $e) {
             throw new ApiException($e->getResponse()->getReasonPhrase(), $e->getResponse()->getStatusCode(), $e);
         }


### PR DESCRIPTION
Useful to easily retrieve internal order id. Better than raw ResponseInterface